### PR TITLE
Improve death animation

### DIFF
--- a/src/deh_tables.c
+++ b/src/deh_tables.c
@@ -407,6 +407,9 @@ const char *const STATE_LIST[] = { // array length left dynamic for sanity testi
 	// technically the player goes here but it's an infinite tic state
 	"S_OBJPLACE_DUMMY",
 
+	"S_KART_LEFTOVER",
+	"S_KART_TIRE",
+
 	// Blue Crawla
 	"S_POSS_STND",
 	"S_POSS_RUN1",
@@ -4389,6 +4392,8 @@ const char *const MOBJTYPE_LIST[] = {  // array length left dynamic for sanity t
 	"MT_THOK", // Thok! mobj
 	"MT_SHADOW", // Linkdraw Shadow (for invisible objects)
 	"MT_PLAYER",
+	"MT_KART_LEFTOVER",
+	"MT_KART_TIRE",
 
 	// Enemies
 	"MT_BLUECRAWLA", // Crawla (Blue)

--- a/src/info.c
+++ b/src/info.c
@@ -876,6 +876,9 @@ state_t states[NUMSTATES] =
 
 	{SPR_NULL, 0, -1, {NULL}, 0, 0, S_OBJPLACE_DUMMY}, // S_OBJPLACE_DUMMY
 
+	{SPR_KART, 0, 1, {A_DeathSpin}, ANG15, 0, S_KART_LEFTOVER}, // S_KART_LEFTOVER
+	{SPR_TIRE, 0, 1, {A_DeathSpin}, ANG30, 0, S_KART_TIRE}, // S_KART_TIRE
+
 	// Blue Crawla
 	{SPR_POSS, 0, 5, {A_Look}, 0, 0, S_POSS_STND},   // S_POSS_STND
 	{SPR_POSS, 0, 3, {A_Chase}, 0, 0, S_POSS_RUN2},   // S_POSS_RUN1
@@ -5111,6 +5114,60 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] =
 		sfx_None,       // activesound
 		MF_SOLID|MF_SHOOTABLE|MF_DONTENCOREMAP|MF_APPLYTERRAIN, // flags
 		(statenum_t)MT_THOK // raisestate
+	},
+
+	{           // MT_KART_LEFTOVER
+		4095,            // doomednum
+		S_KART_LEFTOVER, // spawnstate
+		1,              // spawnhealth
+		S_NULL,         // seestate
+		sfx_None,       // seesound
+		0,              // reactiontime
+		sfx_None,       // attacksound
+		S_NULL,         // painstate
+		0,              // painchance
+		sfx_None,       // painsound
+		S_NULL,         // meleestate
+		S_NULL,         // missilestate
+		S_NULL,         // deathstate
+		S_NULL,         // xdeathstate
+		sfx_None,       // deathsound
+		1,              // speed
+		16*FRACUNIT,    // radius
+		48*FRACUNIT,    // height
+		-1,             // display offset
+		1000,           // mass
+		0,              // damage
+		sfx_None,       // activesound
+		MF_NOBLOCKMAP|MF_NOCLIP|MF_NOCLIPHEIGHT|MF_DONTENCOREMAP|MF_APPLYTERRAIN, // flags
+		S_NULL          // raisestate
+	},
+
+	{           // MT_KART_TIRE
+		-1,             // doomednum
+		S_KART_TIRE,    // spawnstate
+		1,              // spawnhealth
+		S_NULL,         // seestate
+		sfx_None,       // seesound
+		0,              // reactiontime
+		sfx_None,       // attacksound
+		S_NULL,         // painstate
+		0,              // painchance
+		sfx_None,       // painsound
+		S_NULL,         // meleestate
+		S_NULL,         // missilestate
+		S_NULL,         // deathstate
+		S_NULL,         // xdeathstate
+		sfx_None,       // deathsound
+		1,              // speed
+		6*FRACUNIT,     // radius
+		12*FRACUNIT,    // height
+		-1,             // display offset
+		1000,           // mass
+		0,              // damage
+		sfx_None,       // activesound
+		MF_NOBLOCKMAP|MF_NOCLIP|MF_NOCLIPHEIGHT|MF_DONTENCOREMAP|MF_APPLYTERRAIN, // flags
+		S_NULL          // raisestate
 	},
 
 	{           // MT_BLUECRAWLA

--- a/src/info.h
+++ b/src/info.h
@@ -563,6 +563,7 @@ void A_ReaperThinker();
 void A_MementosTPParticles();
 void A_FlameShieldPaper();
 void A_InvincSparkleRotate();
+void A_DeathSpin();
 
 extern boolean actionsoverridden[NUMACTIONS];
 
@@ -1375,6 +1376,9 @@ typedef enum state
 
 	// technically the player goes here but it's an infinite tic state
 	S_OBJPLACE_DUMMY,
+
+	S_KART_LEFTOVER,
+	S_KART_TIRE,
 
 	// Blue Crawla
 	S_POSS_STND,
@@ -5396,6 +5400,9 @@ typedef enum mobj_type
 	MT_THOK, // Thok! mobj
 	MT_SHADOW, // Linkdraw Shadow (for invisible objects)
 	MT_PLAYER,
+	MT_KART_LEFTOVER,
+	MT_KART_TIRE,
+
 	// Enemies
 	MT_BLUECRAWLA, // Crawla (Blue)
 	MT_REDCRAWLA, // Crawla (Red)

--- a/src/k_kart.c
+++ b/src/k_kart.c
@@ -1198,6 +1198,14 @@ fixed_t K_GetMobjWeight(mobj_t *mobj, mobj_t *against)
 				break;
 			weight = K_PlayerWeight(mobj, against);
 			break;
+		case MT_KART_LEFTOVER:
+			weight = 5*FRACUNIT/2;
+
+			if (mobj->extravalue1 > 0)
+			{
+				weight = mobj->extravalue1 * (FRACUNIT >> 1);
+			}
+			break;
 		case MT_BUBBLESHIELD:
 			weight = K_PlayerWeight(mobj->target, against);
 			break;

--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -325,6 +325,7 @@ void A_ReaperThinker(mobj_t *actor);
 void A_MementosTPParticles(mobj_t *actor);
 void A_FlameShieldPaper(mobj_t *actor);
 void A_InvincSparkleRotate(mobj_t *actor);
+void A_DeathSpin(mobj_t *actor);
 
 //for p_enemy.c
 
@@ -14322,4 +14323,10 @@ void A_InvincSparkleRotate(mobj_t *actor)
 		ghost->frame |= FF_ADD;
 		ghost->fuse = 4;
 	}
+}
+
+void A_DeathSpin(mobj_t *actor)
+{
+	INT32 locvar1 = var1;
+	actor->angle += locvar1;
 }

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -9554,6 +9554,8 @@ static void P_DefaultMobjShadowScale(mobj_t *thing)
 	switch (thing->type)
 	{
 		case MT_PLAYER:
+			thing->shadowscale = FRACUNIT;
+			break;
 		case MT_SMALLMACE:
 		case MT_BIGMACE:
 		case MT_PUMA:
@@ -9886,6 +9888,9 @@ mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type)
 			break;
 		case MT_POGOSPRING:
 			P_SetScale(mobj, (mobj->destscale = 3 * mobj->destscale / 2));
+			break;
+		case MT_KART_LEFTOVER:
+			mobj->color = SKINCOLOR_RED;
 			break;
 		case MT_EGGROBO1:
 			mobj->movecount = P_RandomKey(13);


### PR DESCRIPTION
Restored a bunch of recently-removed code and adapted it to a new animation that doesn't leave solid objects behind.

Also fixed the player shadow which was broken by the aforementioned code removal.