### PR TITLE
Make ML_BLOCKPLAYERS block players in UDMF maps only

### DIFF
--- a/src/doomdata.h
+++ b/src/doomdata.h
@@ -105,7 +105,7 @@ enum
 	ML_IMPASSABLE    = 0x00000001,
 
 	// Blocks enemies only
-	ML_BLOCKMONSTERS  = 0x00000002,
+	ML_BLOCKMONSTERS = 0x00000002,
 
 	// Backside will not be present at all if not two sided.
 	ML_TWOSIDED      = 0x00000004,
@@ -142,7 +142,7 @@ enum
 	ML_NONET			= 0x00001000,
 
 	// SRB2Kart: Blocks players only; items can be thrown through these.
-	ML_BLOCKPLAYERS = 0x00002000,
+	ML_BLOCKPLAYERS		= 0x00002000,
 
 	// Don't bounce off this wall!
 	ML_NOTBOUNCY		= 0x00004000,

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -1463,11 +1463,11 @@ boolean P_IsLineBlocking(const line_t *ld, const mobj_t *thing)
 			return true;
 		}
 
-		/*if (thing->player)
+		if (udmf && thing->player)
 		{
 			return ((ld->flags & ML_BLOCKPLAYERS) == ML_BLOCKPLAYERS);
 		}
-		else*/ if (thing->flags & (MF_ENEMY|MF_BOSS))
+		else if (thing->flags & (MF_ENEMY|MF_BOSS))
 		{
 			return ((ld->flags & ML_BLOCKMONSTERS) == ML_BLOCKMONSTERS);
 		}

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -1880,7 +1880,7 @@ static void ParseTextmapLinedefParameter(UINT32 i, const char *param, const char
 	// Flags
 	else if (fastcmp(param, "blocking") && fastcmp("true", val))
 		lines[i].flags |= ML_IMPASSABLE;
-	else if (fastcmp(param, "blockplayers") && fastcmp("true", val))
+	else if (fastcmp(param, "blockmonsters") && fastcmp("true", val))
 		lines[i].flags |= ML_BLOCKMONSTERS;
 	else if (fastcmp(param, "twosided") && fastcmp("true", val))
 		lines[i].flags |= ML_TWOSIDED;
@@ -1900,8 +1900,8 @@ static void ParseTextmapLinedefParameter(UINT32 i, const char *param, const char
 		lines[i].flags |= ML_MIDSOLID;
 	else if (fastcmp(param, "wrapmidtex") && fastcmp("true", val))
 		lines[i].flags |= ML_WRAPMIDTEX;
-	else if (fastcmp(param, "blockmonsters") && fastcmp("true", val))
-		lines[i].flags |= ML_BLOCKMONSTERS;
+	else if (fastcmp(param, "blockplayers") && fastcmp("true", val))
+		lines[i].flags |= ML_BLOCKPLAYERS;
 	else if (fastcmp(param, "nonet") && fastcmp("true", val))
 		lines[i].flags |= ML_NONET;
 	else if (fastcmp(param, "netonly") && fastcmp("true", val))


### PR DESCRIPTION
This should allow the flag to serve its purpose on Ring Racers maps without wreaking havoc on Kart maps.