### PR TITLE
Mitigate software renderer performance regression

### DIFF
--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -2084,45 +2084,12 @@ void R_StoreWallRange(INT32 start, INT32 stop)
 			}
 		}
 
-		if (!bothceilingssky && !bothfloorssky || !udmf)
-		{
-			if (worldhigh <= worldbottom && worldhighslope <= worldbottomslope)
-			{
-				ds_p->sprbottomclip = negonearray;
-				ds_p->bsilheight = INT32_MAX;
-				ds_p->silhouette |= SIL_BOTTOM;
-			}
-
-			if (worldlow >= worldtop && worldlowslope >= worldtopslope)
-			{
-				ds_p->sprtopclip = screenheightarray;
-				ds_p->tsilheight = INT32_MIN;
-				ds_p->silhouette |= SIL_TOP;
-			}
-		}
-
 		//SoM: 3/25/2000: This code fixes an automap bug that didn't check
 		// frontsector->ceiling and backsector->floor to see if a door was closed.
 		// Without the following code, sprites get displayed behind closed doors.
 		if (!bothceilingssky && !bothfloorssky || !udmf)
 		{
-			if (doorclosed || (worldhigh <= worldbottom && worldhighslope <= worldbottomslope))
-			{
-				ds_p->sprbottomclip = negonearray;
-				ds_p->bsilheight = INT32_MAX;
-				ds_p->silhouette |= SIL_BOTTOM;
-			}
-
-			if (doorclosed || (worldlow >= worldtop && worldlowslope >= worldtopslope))
-			{                   // killough 1/17/98, 2/8/98
-				ds_p->sprtopclip = screenheightarray;
-				ds_p->tsilheight = INT32_MIN;
-				ds_p->silhouette |= SIL_TOP;
-			}
-
-			//SoM: 3/25/2000: This code fixes an automap bug that didn't check
-			// frontsector->ceiling and backsector->floor to see if a door was closed.
-			// Without the following code, sprites get displayed behind closed doors.
+			if (udmf || !udmf && viewsector != frontsector && viewsector != backsector)
 			{
 				if (doorclosed || (worldhigh <= worldbottom && worldhighslope <= worldbottomslope))
 				{
@@ -2130,8 +2097,9 @@ void R_StoreWallRange(INT32 start, INT32 stop)
 					ds_p->bsilheight = INT32_MAX;
 					ds_p->silhouette |= SIL_BOTTOM;
 				}
+
 				if (doorclosed || (worldlow >= worldtop && worldlowslope >= worldtopslope))
-				{                   // killough 1/17/98, 2/8/98
+				{
 					ds_p->sprtopclip = screenheightarray;
 					ds_p->tsilheight = INT32_MIN;
 					ds_p->silhouette |= SIL_TOP;

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -714,13 +714,15 @@ void R_RenderMaskedSegRange(drawseg_t *ds, INT32 x1, INT32 x2)
 // Loop through R_DrawMaskedColumn calls
 static void R_DrawRepeatMaskedColumn(column_t *col, column_t *bm, INT32 baseclip)
 {
+	INT64 z;
 	while (sprtopscreen < sprbotscreen)
 	{
 		R_DrawMaskedColumn(col, bm, baseclip);
-		if ((INT64)sprtopscreen + dc_texheight*spryscale > (INT64)INT32_MAX) // prevent overflow
+		z = sprtopscreen + (INT64)dc_texheight*spryscale;
+		if (z > (INT64)INT32_MAX) // prevent overflow
 			sprtopscreen = INT32_MAX;
 		else
-			sprtopscreen += dc_texheight*spryscale;
+			sprtopscreen = z;
 	}
 }
 

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -2024,32 +2024,25 @@ void R_StoreWallRange(INT32 start, INT32 stop)
 		worldlow -= viewz;
 		worldlowslope -= viewz;
 
-		if (udmf) // more mess yippie
+		// hack to allow height changes in outdoor areas
+		// This is what gets rid of the upper textures if there should be sky
+		if (frontsector->ceilingpic == skyflatnum
+			&& backsector->ceilingpic == skyflatnum)
 		{
-			// hack to allow height changes in outdoor areas
-			// This is what gets rid of the upper textures if there should be sky
-			if (frontsector->ceilingpic == skyflatnum
-				&& backsector->ceilingpic == skyflatnum)
-			{
+			if (udmf)
 				bothceilingssky = true;
-			}
-
-			// likewise, but for floors and upper textures
-			if (frontsector->floorpic == skyflatnum
-				&& backsector->floorpic == skyflatnum)
-			{
-				bothfloorssky = true;
-			}
-		}
-		else
-		{
-			// hack to allow height changes in outdoor areas
-			if (frontsector->ceilingpic == skyflatnum
-				&& backsector->ceilingpic == skyflatnum)
+			else
 			{
 				worldtopslope = worldhighslope =
 				worldtop = worldhigh;
 			}
+		}
+
+		// likewise, but for floors and upper textures
+		if (frontsector->floorpic == skyflatnum
+			&& backsector->floorpic == skyflatnum)
+		{
+			bothfloorssky = true;
 		}
 
 		ds_p->sprtopclip = ds_p->sprbottomclip = NULL;
@@ -2073,7 +2066,7 @@ void R_StoreWallRange(INT32 start, INT32 stop)
 			}
 		}
 
-		if (!bothceilingssky || !udmf)
+		if (!bothceilingssky)
 		{
 			if (worldtopslope < worldhighslope || worldtop < worldhigh)
 			{
@@ -2146,7 +2139,7 @@ void R_StoreWallRange(INT32 start, INT32 stop)
 			}
 		}
 
-		if (!udmf && bothfloorssky)
+		if (bothfloorssky)
 		{
 			// see double ceiling skies comment
 			// this is the same but for upside down thok barriers where the floor is sky and the ceiling is normal
@@ -2178,7 +2171,7 @@ void R_StoreWallRange(INT32 start, INT32 stop)
 			markfloor = false;
 		}
 
-		if (!udmf && bothceilingssky)
+		if (bothceilingssky)
 		{
 			// double ceiling skies are special
 			// we don't want to lower the ceiling clipping, (no new plane is drawn anyway)
@@ -2213,8 +2206,8 @@ void R_StoreWallRange(INT32 start, INT32 stop)
 
 		if (!bothceilingssky && !bothfloorssky || !udmf)
 		{
-			if ((udmf && ((worldhigh <= worldbottom && worldhighslope <= worldbottomslope)
-				|| (worldlow >= worldtop && worldlowslope >= worldtopslope))) || (! udmf && (backsector->ceilingheight <= frontsector->floorheight ||
+			if (((worldhigh <= worldbottom && worldhighslope <= worldbottomslope)
+				|| (worldlow >= worldtop && worldlowslope >= worldtopslope)) || (!udmf && (backsector->ceilingheight <= frontsector->floorheight ||
 				backsector->floorheight >= frontsector->ceilingheight)))
 			{
 				// closed door
@@ -2223,7 +2216,7 @@ void R_StoreWallRange(INT32 start, INT32 stop)
 		}
 
 		// check TOP TEXTURE
-		if ((udmf && !bothceilingssky || !udmf) && (worldhigh < worldtop || worldhighslope < worldtopslope)) // never draw the top texture if on
+		if (!bothceilingssky && (worldhigh < worldtop || worldhighslope < worldtopslope)) // never draw the top texture if on
 		{
 			fixed_t texheight;
 			// top texture
@@ -2253,7 +2246,7 @@ void R_StoreWallRange(INT32 start, INT32 stop)
 			}
 		}
 		// check BOTTOM TEXTURE
-		if ((udmf && !bothfloorssky || !udmf) && (worldlow > worldbottom || worldlowslope > worldbottomslope)) // never draw the top texture if on
+		if ((!bothfloorssky || !udmf) && (worldlow > worldbottom || worldlowslope > worldbottomslope)) // never draw the top texture if on
 		{
 			// bottom texture
 			bottomtexture = R_GetTextureNum(sidedef->bottomtexture);

--- a/src/sdl/i_video.c
+++ b/src/sdl/i_video.c
@@ -1640,17 +1640,7 @@ static SDL_bool Impl_CreateContext(void)
 		// "direct3d" driver (D3D9) causes Drmingw exchndl
 		// to not write RPT files. Every other driver
 		// seems fine.
-
-		// well then why use the super slow opengl driver?
-		// d3d11 is the fastest out of all of em and works fine with drmingw
-		// for nix opengles2 also does a rather well job
-#ifdef _WIN32
-		if (SDL_SetHint(SDL_HINT_RENDER_DRIVER, "direct3d11") == SDL_FALSE)
-			SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
-#else
-		if (SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengles2") == SDL_FALSE)
-			SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
-#endif
+		SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
 
 		if (!renderer)
 			renderer = SDL_CreateRenderer(window, -1, flags);

--- a/src/sdl/i_video.c
+++ b/src/sdl/i_video.c
@@ -1640,7 +1640,17 @@ static SDL_bool Impl_CreateContext(void)
 		// "direct3d" driver (D3D9) causes Drmingw exchndl
 		// to not write RPT files. Every other driver
 		// seems fine.
-		SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
+
+		// well then why use the super slow opengl driver?
+		// d3d11 is the fastest out of all of em and works fine with drmingw
+		// for nix opengles2 also does a rather well job
+#ifdef _WIN32
+		if (SDL_SetHint(SDL_HINT_RENDER_DRIVER, "direct3d11") == SDL_FALSE)
+			SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
+#else
+		if (SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengles2") == SDL_FALSE)
+			SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
+#endif
 
 		if (!renderer)
 			renderer = SDL_CreateRenderer(window, -1, flags);


### PR DESCRIPTION
https://github.com/NepDisk/blankart/pull/16 seemed to have caused some significant performance loss on certains maps

this tries to mitigate those as best as possible without breaking visuals again

also fixes the overflow check in R_DrawRepeatMaskedColumn overflowing on maps with translucent textures (ex. marsh marble zone)
also cleans up the code a little

also changes the SDL_renderer driver to either use direct3d11 on windows or opengles2 on nix due to significant performance increase in all cases when running software
If either one of those is unavailible it will just revert to using Opengl acceleration

![kart0013](https://github.com/user-attachments/assets/9d3d4269-4a5d-4c8f-b41d-f52f411b3a60)
![kart0014](https://github.com/user-attachments/assets/9c4364fc-4f3c-4b16-90d4-04de241da6e3)
