### PR TITLE
Flame Shield Rework

### DIFF
--- a/src/d_player.h
+++ b/src/d_player.h
@@ -450,8 +450,8 @@ typedef struct player_s
 	UINT8 bubblecool;	// Bubble Shield use cooldown
 	UINT8 bubbleblowup;	// Bubble Shield usage blowup
 	UINT16 flamedash;	// Flame Shield dash power
-	UINT16 flamemeter;	// Flame Shield dash meter left
-	UINT8 flamelength;	// Flame Shield dash meter, number of segments
+	INT32 flametimer;	// Flame Shield dash meter left
+	UINT8 flamestore;	// Flame Shield reserve boost
 
 	UINT16 hyudorotimer;	// Duration of the Hyudoro offroad effect itself
 	SINT8 stealingtimer;	// you are stealing

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -679,7 +679,6 @@ extern INT32 greasetics;
 extern INT32 wipeoutslowtime;
 extern INT32 wantedreduce;
 extern INT32 wantedfrequency;
-extern INT32 flameseg;
 
 extern UINT8 introtoplay;
 extern UINT8 creditscutscene;

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -269,7 +269,6 @@ INT32 greasetics = 3*TICRATE;
 INT32 wipeoutslowtime = 20;
 INT32 wantedreduce = 5*TICRATE;
 INT32 wantedfrequency = 10*TICRATE;
-INT32 flameseg = TICRATE/4;
 
 UINT8 use1upSound = 0;
 UINT8 maxXtraLife = 2; // Max extra lives from rings

--- a/src/k_botitem.c
+++ b/src/k_botitem.c
@@ -1184,22 +1184,23 @@ static void K_BotItemBubble(player_t *player, ticcmd_t *cmd)
 --------------------------------------------------*/
 static void K_BotItemFlame(player_t *player, ticcmd_t *cmd)
 {
-	if (player->botvars.itemconfirm > 0)
+	if (P_IsObjectOnGround(player->mo) == false)
 	{
-		player->botvars.itemconfirm--;
+		// Don't use while mid-air.
+		return;
 	}
-	else if (player->pflags & PF_HOLDREADY)
-	{
-		INT32 flamemax = player->flamelength * flameseg;
 
-		if (player->flamemeter < flamemax || flamemax == 0)
+	if (player->botvars.itemconfirm > TICRATE)
+	{
+		if (player->flametimer > 0)
 		{
 			cmd->buttons |= BT_ATTACK;
+			player->botvars.itemconfirm = 0;
 		}
-		else
-		{
-			player->botvars.itemconfirm = 3*flamemax/4;
-		}
+	}
+	else
+	{
+		player->botvars.itemconfirm++;
 	}
 }
 
@@ -1320,6 +1321,10 @@ void K_BotItemUsage(player_t *player, ticcmd_t *cmd, INT16 turnamt)
 			{
 				K_BotItemRocketSneaker(player, cmd);
 			}
+			else if (player->flametimer > 0)
+			{
+				K_BotItemFlame(player, cmd);
+			}
 			else
 			{
 				switch (player->itemtype)
@@ -1342,6 +1347,12 @@ void K_BotItemUsage(player_t *player, ticcmd_t *cmd, INT16 turnamt)
 						break;
 					case KITEM_ROCKETSNEAKER:
 						if (player->rocketsneakertimer <= 0)
+						{
+							K_BotItemGenericTap(player, cmd);
+						}
+						break;
+				case KITEM_FLAMESHIELD:
+						if (player->flametimer <= 0)
 						{
 							K_BotItemGenericTap(player, cmd);
 						}
@@ -1412,9 +1423,6 @@ void K_BotItemUsage(player_t *player, ticcmd_t *cmd, INT16 turnamt)
 						break;
 					case KITEM_BUBBLESHIELD:
 						K_BotItemBubble(player, cmd);
-						break;
-					case KITEM_FLAMESHIELD:
-						K_BotItemFlame(player, cmd);
 						break;
 				}
 			}

--- a/src/k_collide.c
+++ b/src/k_collide.c
@@ -59,7 +59,7 @@ boolean K_OrbinautJawzCollide(mobj_t *t1, mobj_t *t2)
 		if (t2->player->hyudorotimer)
 			return true; // no interaction
 
-		if (t2->player->flamedash && t2->player->itemtype == KITEM_FLAMESHIELD)
+		if (t2->player->flamestore && t2->player->itemtype == KITEM_FLAMESHIELD)
 		{
 			// Melt item
 			S_StartSound(t2, sfx_s3k43);
@@ -153,7 +153,7 @@ boolean K_BananaBallhogCollide(mobj_t *t1, mobj_t *t2)
 		if (t1->type == MT_BANANA && t1->health > 1)
 			S_StartSound(t2, sfx_bsnipe);
 
-		if (t2->player->flamedash && t2->player->itemtype == KITEM_FLAMESHIELD)
+		if (t2->player->flamestore && t2->player->itemtype == KITEM_FLAMESHIELD)
 		{
 			// Melt item
 			S_StartSound(t2, sfx_s3k43);
@@ -243,7 +243,7 @@ boolean K_EggItemCollide(mobj_t *t1, mobj_t *t2)
 			t2->player->roulettetype = 2;
 		}
 
-		if (t2->player->flamedash && t2->player->itemtype == KITEM_FLAMESHIELD)
+		if (t2->player->flamestore && t2->player->itemtype == KITEM_FLAMESHIELD)
 		{
 			// Melt item
 			S_StartSound(t2, sfx_s3k43);
@@ -459,7 +459,7 @@ boolean K_LandMineCollide(mobj_t *t1, mobj_t *t2)
 		if (t1->health > 1)
 			S_StartSound(t2, sfx_bsnipe);
 
-		if (t2->player->flamedash && t2->player->itemtype == KITEM_FLAMESHIELD)
+		if (t2->player->flamestore && t2->player->itemtype == KITEM_FLAMESHIELD)
 		{
 			// Melt item
 			S_StartSound(t2, sfx_s3k43);
@@ -828,8 +828,8 @@ boolean K_SMKIceBlockCollide(mobj_t *t1, mobj_t *t2)
 
 boolean K_PvPTouchDamage(mobj_t *t1, mobj_t *t2)
 {
-	const boolean flameT1 = (t1->player->flamedash > 0 && t1->player->itemtype == KITEM_FLAMESHIELD);
-	const boolean flameT2 = (t2->player->flamedash > 0 && t2->player->itemtype == KITEM_FLAMESHIELD);
+	const boolean flameT1 = (t1->player->flamestore > 0 && t1->player->itemtype == KITEM_FLAMESHIELD);
+	const boolean flameT2 = (t2->player->flamestore > 0 && t2->player->itemtype == KITEM_FLAMESHIELD);
 
 	boolean t1Condition = false;
 	boolean t2Condition = false;
@@ -912,8 +912,8 @@ boolean K_PvPTouchDamage(mobj_t *t1, mobj_t *t2)
 
 	if (!ringsdisabled) // Ring sting, this is a bit more unique
 	{
-		t1Condition = (K_GetShieldFromItem(t2->player->itemtype) == KSHIELD_NONE);
-		t2Condition = (K_GetShieldFromItem(t1->player->itemtype) == KSHIELD_NONE);
+		t1Condition = (K_GetShieldFromPlayer(t2->player) == KSHIELD_NONE);
+		t2Condition = (K_GetShieldFromPlayer(t1->player) == KSHIELD_NONE);
 
 		if (t1Condition == true)
 		{

--- a/src/k_hud.c
+++ b/src/k_hud.c
@@ -1170,6 +1170,17 @@ static void K_drawKartItem(void)
 			else
 				localpatch = kp_nodraw;
 		}
+		else if (stplyr->flametimer > 1)
+		{
+			itembar = stplyr->flametimer;
+			maxl = (itemtime*3) - barlength;
+			localbg = kp_itembg[offset+1];
+
+			if (leveltime & 1)
+				localpatch = kp_flameshield[offset];
+			else
+				localpatch = kp_nodraw;
+		}
 		else if (stplyr->growshrinktimer > 0)
 		{
 			if (stplyr->growcancel > 0)
@@ -1368,51 +1379,6 @@ static void K_drawKartItem(void)
 	// Quick Eggman numbers
 	if (stplyr->eggmanexplode > 1)
 		V_DrawScaledPatch(fx+17, fy+13-offset, V_HUDTRANS|fflags, kp_eggnum[min(3, G_TicsToSeconds(stplyr->eggmanexplode))]);
-
-	if (stplyr->itemtype == KITEM_FLAMESHIELD && stplyr->flamelength > 0)
-	{
-		INT32 numframes = 104;
-		INT32 absolutemax = 16 * flameseg;
-		INT32 flamemax = stplyr->flamelength * flameseg;
-		INT32 flamemeter = min(stplyr->flamemeter, flamemax);
-
-		INT32 bf = 16 - stplyr->flamelength;
-		INT32 ff = numframes - ((flamemeter * numframes) / absolutemax);
-		INT32 fmin = (8 * (bf-1));
-
-		INT32 xo = 6, yo = 4;
-		INT32 flip = 0;
-
-		if (offset)
-		{
-			xo++;
-
-			if (stplyr == &players[displayplayers[0]] || stplyr == &players[displayplayers[2]]) // Flip for P1 and P3 (yes, that's correct)
-			{
-				xo -= 62;
-				flip = V_FLIP;
-			}
-		}
-
-		if (ff < fmin)
-			ff = fmin;
-
-		if (bf >= 0 && bf < 16)
-			V_DrawScaledPatch(fx-xo, fy-yo, V_HUDTRANS|fflags|flip, kp_flameshieldmeter_bg[bf][offset]);
-
-		if (ff >= 0 && ff < numframes && stplyr->flamemeter > 0)
-		{
-			if ((stplyr->flamemeter > flamemax) && (leveltime & 1))
-			{
-				UINT8 *fsflash = R_GetTranslationColormap(TC_BLINK, SKINCOLOR_WHITE, GTC_CACHE);
-				V_DrawMappedPatch(fx-xo, fy-yo, V_HUDTRANS|fflags|flip, kp_flameshieldmeter[ff][offset], fsflash);
-			}
-			else
-			{
-				V_DrawScaledPatch(fx-xo, fy-yo, V_HUDTRANS|fflags|flip, kp_flameshieldmeter[ff][offset]);
-			}
-		}
-	}
 }
 
 void K_drawKartTimestamp(tic_t drawtime, INT32 TX, INT32 TY, INT16 emblemmap, UINT8 mode)

--- a/src/k_kart.c
+++ b/src/k_kart.c
@@ -6751,11 +6751,6 @@ void K_KartPlayerThink(player_t *player, ticcmd_t *cmd)
 	if (player->stealingtimer == 0 && player->stolentimer == 0
 		&& player->flametimer > 0)
 		player->flametimer--;
-	
-	if (player->flametimer <= 0)
-	{
-		K_DropHnextList(player, false);
-	}
 
 	if (player->hyudorotimer)
 		player->hyudorotimer--;

--- a/src/k_kart.c
+++ b/src/k_kart.c
@@ -399,6 +399,23 @@ static INT32 K_KartItemOddsBattle[NUMKARTRESULTS][2] =
 #define SPBFORCEDIST (15*DISTVAR) // Distance when SPB is forced onto 2nd place
 #define ENDDIST (12*DISTVAR) // Distance when the game stops giving you bananas
 
+INT32 K_GetShieldFromPlayer(player_t *player)
+{
+	
+	if (player->flametimer > 0)
+	{
+		return KSHIELD_FLAME;
+	}
+	
+	switch (player->itemtype)
+	{
+		case KITEM_LIGHTNINGSHIELD: return KSHIELD_LIGHTNING;
+		case KITEM_BUBBLESHIELD: return KSHIELD_BUBBLE;
+		//case KITEM_FLAMESHIELD: return KSHIELD_FLAME; not active until flametimer is active.
+		default: return KSHIELD_NONE;
+	}
+}
+
 INT32 K_GetShieldFromItem(INT32 item)
 {
 	switch (item)
@@ -601,7 +618,7 @@ INT32 K_KartGetItemOdds(
 		if (players[i].exiting)
 			pexiting++;
 
-		if (shieldtype != KSHIELD_NONE && shieldtype == K_GetShieldFromItem(players[i].itemtype))
+		if (shieldtype != KSHIELD_NONE && shieldtype == K_GetShieldFromPlayer(&players[i]))
 		{
 			// Don't allow more than one of each shield type at a time
 			return 0;
@@ -2649,7 +2666,7 @@ boolean K_ApplyOffroad(player_t *player)
 
 boolean K_SlopeResistance(player_t *player)
 {
-	if (player->invincibilitytimer || player->sneakertimer || player->flamedash)
+	if (player->invincibilitytimer || player->sneakertimer || player->flamestore)
 		return true;
 	return false;
 }
@@ -2687,7 +2704,7 @@ tripwirepass_t K_TripwirePassConditions(player_t *player)
 		return TRIPWIRE_BLASTER;
 
 	if (
-			player->flamedash ||
+			player->flamestore ||
 			((player->speed > K_PlayerTripwireSpeedThreshold(player)) && player->tripwireReboundDelay == 0)
 	)
 		return TRIPWIRE_BOOST;
@@ -2715,8 +2732,8 @@ boolean K_WaterRun(player_t *player)
 
 static fixed_t K_FlameShieldDashVar(INT32 val)
 {
-	// 1 second = 75% + 50% top speed
-	return (3*FRACUNIT/4) + (((val * FRACUNIT) / TICRATE) / 2);
+	// 1 second = 15% + ????% top speed
+	return (FRACUNIT/6) + (((val * (FRACUNIT)) / TICRATE) / 2);
 }
 
 // sets boostpower, speedboost and accelboost to whatever we need it to be
@@ -2782,11 +2799,24 @@ static void K_GetKartBoostPower(player_t *player)
 	{
 		ADDBOOST(FRACUNIT/5, 0); // + 20% top speed, + 0% acceleration, +25% handling
 	}
-
-	if (player->flamedash) // Flame Shield dash
+	
+	if (player->flamestore) // Flame Shield dash
 	{
 		fixed_t dash = K_FlameShieldDashVar(player->flamedash);
-		ADDBOOST( dash,	3*FRACUNIT); // + infinite top speed // + 300% acceleration
+		fixed_t intermediate = 0;
+		fixed_t boost = 0;
+		fixed_t val = 52428; // Rim idea: diminish starts around 1.2x sneaker speed and plateaus around 1.4-1.5x
+		fixed_t accel = 3*FRACUNIT;
+		
+		intermediate = FixedDiv(FixedMul(val, FRACUNIT*-1/2) - FRACUNIT/4,-val+FRACUNIT/2);
+		boost = FixedMul(val,(FRACUNIT-FixedDiv(FRACUNIT,(dash+intermediate))));
+		
+		if (player->drift)
+		{
+			accel += FRACUNIT/2 + FRACUNIT*2;
+		}
+		
+		ADDBOOST(boost, accel);
 	}
 
 	if (player->startboost) // Startup Boost
@@ -4953,7 +4983,7 @@ void K_DropHnextList(player_t *player, boolean keepshields)
 	INT32 flip;
 	mobjtype_t type;
 	boolean orbit, ponground, dropall = true;
-	INT32 shield = K_GetShieldFromItem(player->itemtype);
+	INT32 shield = K_GetShieldFromPlayer(player);
 
 	if (work == NULL || P_MobjWasRemoved(work))
 	{
@@ -6660,6 +6690,9 @@ void K_KartPlayerThink(player_t *player, ticcmd_t *cmd)
 
 	if (player->flamedash)
 		player->flamedash--;
+	
+	if (player->flamestore)
+		player->flamestore--;
 
 	if (player->sneakertimer && player->wipeoutslow > 0 && player->wipeoutslow < wipeoutslowtime+1)
 		player->wipeoutslow = wipeoutslowtime+1;
@@ -6714,6 +6747,15 @@ void K_KartPlayerThink(player_t *player, ticcmd_t *cmd)
 	if (player->stealingtimer == 0 && player->stolentimer == 0
 		&& player->rocketsneakertimer)
 		player->rocketsneakertimer--;
+	
+	if (player->stealingtimer == 0 && player->stolentimer == 0
+		&& player->flametimer > 0)
+		player->flametimer--;
+	
+	if (player->flametimer <= 0)
+	{
+		K_DropHnextList(player, false);
+	}
 
 	if (player->hyudorotimer)
 		player->hyudorotimer--;
@@ -6805,9 +6847,9 @@ void K_KartPlayerThink(player_t *player, ticcmd_t *cmd)
 		player->bubblecool = 0;
 	}
 
-	if (player->itemtype != KITEM_FLAMESHIELD)
+	if (player->flametimer == 0)
 	{
-		if (player->flamedash)
+		if (player->flamestore)
 			K_FlameDashLeftoverSmoke(player->mo);
 	}
 
@@ -8083,36 +8125,6 @@ void K_StripOther(player_t *player)
 	}
 }
 
-static INT32 K_FlameShieldMax(player_t *player)
-{
-	UINT32 disttofinish = 0;
-	UINT32 distv = DISTVAR;
-	UINT8 numplayers = 0;
-	UINT8 i;
-
-	for (i = 0; i < MAXPLAYERS; i++)
-	{
-		if (playeringame[i] && !players[i].spectator)
-			numplayers++;
-		if (players[i].position == 1)
-			disttofinish = players[i].distancetofinish;
-	}
-
-	if (numplayers <= 1 || gametype == GT_BATTLE)
-	{
-		return 16; // max when alone, for testing
-		// and when in battle, for chaos
-	}
-	else if (player->position == 1)
-	{
-		return 0; // minimum for first
-	}
-
-	disttofinish = player->distancetofinish - disttofinish;
-	distv = FixedMul(distv * FRACUNIT, mapobjectscale) / FRACUNIT;
-	return min(16, 1 + (disttofinish / distv));
-}
-
 SINT8 K_Sliptiding(player_t *player)
 {
 	return player->drift ? 0 : player->aizdriftstrat;
@@ -8305,6 +8317,45 @@ void K_MoveKartPlayer(player_t *player, boolean onground)
 							player->rocketsneakertimer = 1;
 						else
 							player->rocketsneakertimer -= 3*TICRATE;
+					}
+				}
+				// Flame Shield usage
+				else if (player->flametimer > 0)
+				{
+					if ((cmd->buttons & BT_ATTACK) && NO_HYUDORO)
+					{
+						// TODO: gametyperules
+						const SINT8 incr = gametype == GT_BATTLE ? 3 : 2;
+						const SINT8 metincr = gametype == GT_BATTLE ? 4 : 3;
+						const SINT8 comincr = gametype == GT_BATTLE ? 8 : 4;
+
+						if (player->flamestore == 0)
+						{
+							S_StartSound(player->mo, sfx_s3k43);
+							K_PlayBoostTaunt(player->mo);
+						}
+
+						player->flamedash += incr;
+						player->flamestore = min(player->flamestore + metincr, TICRATE*2);
+						player->flametimer -= comincr;
+						
+						if (player->flametimer <= 0)
+						{
+							K_DropHnextList(player, false);
+						}
+
+						if (!onground)
+						{
+							P_Thrust(
+								player->mo, K_MomentumAngle(player->mo),
+								FixedMul(player->mo->scale, K_GetKartGameSpeedScalar(gamespeed))
+							);
+						}
+						
+					}
+					else
+					{
+						player->pflags |= PF_HOLDREADY;
 					}
 				}
 				// Grow Canceling
@@ -8725,84 +8776,19 @@ void K_MoveKartPlayer(player_t *player, boolean onground)
 							}
 							break;
 						case KITEM_FLAMESHIELD:
-							if (player->curshield != KSHIELD_FLAME)
+							
+							if (ATTACK_IS_DOWN && !HOLDING_ITEM && NO_HYUDORO && player->flametimer == 0)
 							{
-								mobj_t *shield = P_SpawnMobj(player->mo->x, player->mo->y, player->mo->z, MT_FLAMESHIELD);
-								P_SetScale(shield, (shield->destscale = (5*shield->destscale)>>2));
-								P_SetTarget(&shield->target, player->mo);
-								S_StartSound(player->mo, sfx_s3k3e);
-								player->curshield = KSHIELD_FLAME;
-							}
-
-							if (!HOLDING_ITEM && NO_HYUDORO)
-							{
-								INT32 destlen = K_FlameShieldMax(player);
-								INT32 flamemax = 0;
-
-								if (player->flamelength < destlen)
-									player->flamelength++; // Can always go up!
-
-								flamemax = player->flamelength * flameseg;
-								if (flamemax > 0)
-									flamemax += TICRATE; // leniency period
-
-								if ((cmd->buttons & BT_ATTACK) && (player->pflags & PF_HOLDREADY))
+								player->flametimer = (itemtime*3);
+								player->itemamount--;
+								
+								if (player->curshield != KSHIELD_FLAME)
 								{
-									// TODO: gametyperules
-									const INT32 incr = gametype == GT_BATTLE ? 4 : 2;
-
-									if (player->flamedash == 0)
-									{
-										S_StartSound(player->mo, sfx_s3k43);
-										K_PlayBoostTaunt(player->mo);
-									}
-
-									player->flamedash += incr;
-									player->flamemeter += incr;
-
-									if (!onground)
-									{
-										P_Thrust(
-											player->mo, K_MomentumAngle(player->mo),
-											FixedMul(player->mo->scale, K_GetKartGameSpeedScalar(gamespeed))
-										);
-									}
-
-									if (player->flamemeter > flamemax)
-									{
-										P_Thrust(
-											player->mo, player->mo->angle,
-											FixedMul((50*player->mo->scale), K_GetKartGameSpeedScalar(gamespeed))
-										);
-
-										player->flamemeter = 0;
-										player->flamelength = 0;
-										player->pflags &= ~PF_HOLDREADY;
-										player->itemamount--;
-									}
-								}
-								else
-								{
-									player->pflags |= PF_HOLDREADY;
-
-									// TODO: gametyperules
-									if (gametype != GT_BATTLE || leveltime % 6 == 0)
-									{
-										if (player->flamemeter > 0)
-											player->flamemeter--;
-									}
-
-									if (player->flamelength > destlen)
-									{
-										player->flamelength--; // Can ONLY go down if you're not using it
-
-										flamemax = player->flamelength * flameseg;
-										if (flamemax > 0)
-											flamemax += TICRATE; // leniency period
-									}
-
-									if (player->flamemeter > flamemax)
-										player->flamemeter = flamemax;
+									mobj_t *shield = P_SpawnMobj(player->mo->x, player->mo->y, player->mo->z, MT_FLAMESHIELD);
+									P_SetScale(shield, (shield->destscale = (5*shield->destscale)>>2));
+									P_SetTarget(&shield->target, player->mo);
+									S_StartSound(player->mo, sfx_s3k3e);
+									player->curshield = KSHIELD_FLAME;
 								}
 							}
 							break;
@@ -8880,13 +8866,13 @@ void K_MoveKartPlayer(player_t *player, boolean onground)
 			player->itemtype = KITEM_NONE;
 		}
 
-		if (K_GetShieldFromItem(player->itemtype) == KSHIELD_NONE)
+		if (K_GetShieldFromPlayer(player) == KSHIELD_NONE)
 		{
 			player->curshield = KSHIELD_NONE; // RESET shield type
 			player->bubbleblowup = 0;
 			player->bubblecool = 0;
-			player->flamelength = 0;
-			player->flamemeter = 0;
+			//player->flamedash = 0;
+			player->flametimer = 0;
 		}
 
 		if (spbplace == -1 || player->position != spbplace)

--- a/src/k_kart.c
+++ b/src/k_kart.c
@@ -7631,6 +7631,16 @@ INT16 K_GetKartTurnValue(player_t *player, INT16 turnvalue)
 
 	if (player->invincibilitytimer || player->sneakertimer || player->growshrinktimer > 0)
 		turnvalue = FixedMul(turnvalue, FixedDiv(5*FRACUNIT, 4*FRACUNIT));
+	
+	if (player->flamedash && player->flamestore) // Reduce turning
+	{
+		fixed_t dashval = ((player->flamedash<<FRACBITS) / TICRATE) / 40; // 1 second = -2.5% handling
+		if (dashval > FRACUNIT)
+			return 0; // NO MORE TURNING!
+		turnvalue = FixedMul(turnvalue, FRACUNIT-dashval);
+		//CONS_Printf("dashval: %d\n",dashval);
+		//CONS_Printf("turnval: %d\n",turnvalue);
+	}
 
 	return turnvalue;
 }
@@ -7808,10 +7818,10 @@ static void K_KartDrift(player_t *player, boolean onground)
 		player->pflags &= ~(PF_BRAKEDRIFT|PF_GETSPARKS);
 	}
 
-	if ((player->sneakertimer == 0)
-	|| (!stplyr->cmd.turning)
+	if ( (!(player->sneakertimer || player->flamestore))
+	|| (!player->cmd.turning)
 	|| (!player->aizdriftstrat)
-	|| (stplyr->cmd.turning > 0) != (player->aizdriftstrat > 0))
+	|| (player->cmd.turning > 0) != (player->aizdriftstrat > 0))
 	{
 		if (!player->drift)
 			player->aizdriftstrat = 0;

--- a/src/k_kart.c
+++ b/src/k_kart.c
@@ -8325,7 +8325,7 @@ void K_MoveKartPlayer(player_t *player, boolean onground)
 							player->pflags |= PF_HOLDREADY;
 						}
 						
-						if ((cmd->buttons & BT_ATTACK) && (player->pflags & PF_HOLDREADY))
+						if ((cmd->buttons & BT_ATTACK) && (player->pflags & PF_HOLDREADY) && onground)
 						{
 							// TODO: gametyperules
 							const SINT8 incr = gametype == GT_BATTLE ? 3 : 2;
@@ -8347,13 +8347,13 @@ void K_MoveKartPlayer(player_t *player, boolean onground)
 								K_DropHnextList(player, false);
 							}
 
-							if (!onground && (leveltime % 8))
+							/*if (!onground && (leveltime % 8))
 							{
 								P_Thrust(
 									player->mo, K_MomentumAngle(player->mo),
 									mapobjectscale
 								);
-							}
+							}*/
 							
 						}
 					}

--- a/src/k_kart.h
+++ b/src/k_kart.h
@@ -37,6 +37,7 @@ UINT8 K_FindUseodds(player_t *player, fixed_t mashed, UINT32 pdis, UINT8 bestbum
 fixed_t K_ItemOddsScale(UINT8 numPlayers, boolean spbrush);
 UINT32 K_ScaleItemDistance(UINT32 distance, UINT8 numPlayers, boolean spbrush);
 INT32 K_KartGetItemOdds(UINT8 pos, SINT8 item, UINT32 ourDist, fixed_t mashed, boolean spbrush, boolean bot, boolean rival);
+INT32 K_GetShieldFromPlayer(player_t *player);
 INT32 K_GetShieldFromItem(INT32 item);
 fixed_t K_GetMobjWeight(mobj_t *mobj, mobj_t *against);
 boolean K_KartBouncing(mobj_t *mobj1, mobj_t *mobj2);

--- a/src/lua_playerlib.c
+++ b/src/lua_playerlib.c
@@ -318,10 +318,10 @@ static int player_get(lua_State *L)
 		lua_pushinteger(L, plr->bubbleblowup);
 	else if (fastcmp(field,"flamedash"))
 		lua_pushinteger(L, plr->flamedash);
-	else if (fastcmp(field,"flamemeter"))
-		lua_pushinteger(L, plr->flamemeter);
-	else if (fastcmp(field,"flamelength"))
-		lua_pushinteger(L, plr->flamelength);
+	else if (fastcmp(field,"flametimer"))
+		lua_pushinteger(L, plr->flametimer);
+	else if (fastcmp(field,"flamestore"))
+		lua_pushinteger(L, plr->flamestore);
 	else if (fastcmp(field,"hyudorotimer"))
 		lua_pushinteger(L, plr->hyudorotimer);
 	else if (fastcmp(field,"stealingtimer"))
@@ -682,10 +682,10 @@ static int player_set(lua_State *L)
 		plr->bubbleblowup = luaL_checkinteger(L, 3);
 	else if (fastcmp(field,"flamedash"))
 		plr->flamedash = luaL_checkinteger(L, 3);
-	else if (fastcmp(field,"flamemeter"))
-		plr->flamemeter = luaL_checkinteger(L, 3);
-	else if (fastcmp(field,"flamelength"))
-		plr->flamelength = luaL_checkinteger(L, 3);
+	else if (fastcmp(field,"flametimer"))
+		plr->flametimer = luaL_checkinteger(L, 3);
+	else if (fastcmp(field,"flamestore"))
+		plr->flamestore = luaL_checkinteger(L, 3);
 	else if (fastcmp(field,"hyudorotimer"))
 		plr->hyudorotimer = luaL_checkinteger(L, 3);
 	else if (fastcmp(field,"stealingtimer"))

--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -131,7 +131,8 @@ boolean P_CanPickupItem(player_t *player, UINT8 weapon)
 				|| player->squishedtimer > 0
 				|| player->invincibilitytimer > 0
 				|| player->growshrinktimer > 0
-				|| player->hyudorotimer > 0)
+				|| player->hyudorotimer > 0
+				|| player->flametimer > 0)
 				return false;
 
 			// Already have fake
@@ -145,7 +146,8 @@ boolean P_CanPickupItem(player_t *player, UINT8 weapon)
 			if (player->stealingtimer || player->stolentimer
 				|| player->rocketsneakertimer
 				|| player->eggmanexplode
-				|| (player->growshrinktimer > 0))
+				|| (player->growshrinktimer > 0)
+				|| player->flametimer)
 				return false;
 
 			// Item slot already taken up
@@ -154,7 +156,7 @@ boolean P_CanPickupItem(player_t *player, UINT8 weapon)
 				|| (player->pflags & PF_ITEMOUT))
 				return false;
 
-			if (weapon == 3 && K_GetShieldFromItem(player->itemtype) != KSHIELD_NONE)
+			if (weapon == 3 && K_GetShieldFromPlayer(player) != KSHIELD_NONE)
 				return false; // No stacking shields!
 		}
 	}
@@ -422,7 +424,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher, boolean heightcheck)
 			// kill
 			if (player->invincibilitytimer > 0
 				|| player->growshrinktimer > 0
-				|| player->flamedash > 0)
+				|| player->flamestore > 0)
 			{
 				P_KillMobj(special, toucher, toucher, DMG_NORMAL);
 				return;
@@ -1455,7 +1457,7 @@ void P_KillMobj(mobj_t *target, mobj_t *inflictor, mobj_t *source, UINT8 damaget
 				else
 				{
 					player->itemtype = target->threshold;
-					if (K_GetShieldFromItem(player->itemtype) != KSHIELD_NONE) // never give more than 1 shield
+					if (K_GetShieldFromPlayer(player) != KSHIELD_NONE) // never give more than 1 shield
 						player->itemamount = 1;
 					else
 						player->itemamount = max(1, target->movecount);
@@ -2263,7 +2265,7 @@ void P_PlayerRingBurst(player_t *player, INT32 num_rings)
 		return;
 
 	// Have a shield? You get hit, but don't lose your rings!
-	if (K_GetShieldFromItem(player->itemtype) != KSHIELD_NONE)
+	if (K_GetShieldFromPlayer(player) != KSHIELD_NONE)
 		return;
 
 	// 20 is the maximum number of rings that can be taken from you at once - half the span of your counter

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -7491,7 +7491,7 @@ static boolean P_MobjRegularThink(mobj_t *mobj)
 			}
 			P_SetScale(mobj, (mobj->destscale = (5*mobj->target->scale)>>2));
 			curstate = ((mobj->tics == 1) ? (mobj->state->nextstate) : ((statenum_t)(mobj->state-states)));
-			if (mobj->target->player->flamedash)
+			if (mobj->target->player->flamestore)
 			{
 				if (curstate != S_FLAMESHIELDDASH)
 					P_SetMobjState(mobj, S_FLAMESHIELDDASH);

--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -300,8 +300,8 @@ static void P_NetArchivePlayers(void)
 		WRITEUINT8(save_p, players[i].bubblecool);
 		WRITEUINT8(save_p, players[i].bubbleblowup);
 		WRITEUINT16(save_p, players[i].flamedash);
-		WRITEUINT16(save_p, players[i].flamemeter);
-		WRITEUINT8(save_p, players[i].flamelength);
+		WRITEINT32(save_p, players[i].flametimer);
+		WRITEUINT8(save_p, players[i].flamestore);
 
 		WRITEUINT16(save_p, players[i].hyudorotimer);
 		WRITESINT8(save_p, players[i].stealingtimer);
@@ -587,8 +587,8 @@ static void P_NetUnArchivePlayers(void)
 		players[i].bubblecool = READUINT8(save_p);
 		players[i].bubbleblowup = READUINT8(save_p);
 		players[i].flamedash = READUINT16(save_p);
-		players[i].flamemeter = READUINT16(save_p);
-		players[i].flamelength = READUINT8(save_p);
+		players[i].flametimer = READINT32(save_p);
+		players[i].flamestore = READUINT8(save_p);
 
 		players[i].hyudorotimer = READUINT16(save_p);
 		players[i].stealingtimer = READSINT8(save_p);

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -690,7 +690,7 @@ void P_PlayRinglossSound(mobj_t *source)
 	if (ringsdisabled)
 		return;
 	
-	if (source->player && K_GetShieldFromItem(source->player->itemtype) != KSHIELD_NONE)
+	if (source->player && K_GetShieldFromPlayer(source->player) != KSHIELD_NONE)
 		S_StartSound(source, sfx_s1a3); // Shield hit (no ring loss)
 	else if (source->player && source->player->rings <= 0)
 		S_StartSound(source, sfx_s1a6); // Ring debt (lessened ring loss)
@@ -2317,7 +2317,7 @@ void P_MovePlayer(player_t *player)
 	////////////////////////////
 
 	// SRB2kart - Drifting smoke and fire
-	if ((player->sneakertimer || player->flamedash)
+	if ((player->sneakertimer || player->flamestore)
 		&& onground && (leveltime & 1))
 		K_SpawnBoostTrail(player);
 


### PR DESCRIPTION
The idea is to return it as a meter item while keeping and putting a restriction on the speed building and storing part from the previous version. Using the boost while its active will drain time from the main timer to fill up reserve as it were, this reserve is what handles the leftover boost duration from usage which caps at 2 seconds, this is whats used up when not holding the button or having the shield. The speed increase from using the flame shield more and more now diminishes to around 81 fu/t on knuckles on hard for example and is done separately from the main drain timer and the reserve.

You could think of the idea like a battery of sorts. You fill the leftover boost duration up and it drains on its own

This makes it so that holding the button wastes it but lets you go fast while being smart with its usage gets you more out distance of it.

- [ ] Give this better visuals so you can tell when you have full reserve.
- [x] Make use of hold button input player flag
- [ ] Make bots use it in this new style properly